### PR TITLE
Fix bad argument to vips_image_remove

### DIFF
--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -473,7 +473,7 @@ local instance_methods = {
     end,
 
     remove = function(self, name)
-        return vips_lib.vips_image_remove(self, name) ~= 0
+        return vips_lib.vips_image_remove(self.vimage, name) ~= 0
     end,
 
     -- standard header fields


### PR DESCRIPTION
Will otherwise throw 
```
bad argument #1 to 'vips_image_remove' (cannot convert 'table' to 'struct _VipsImage *')
```

when removing a piece of metadata. For e.g. when doing: 
```lua
-- Remove EXIF Orientation from image, if any
if image:get_typeof('orientation') ~= 0 then
    image:remove('orientation')
end
```

If you wondered why I test with lua-vips:
I'm currently doing speed comparisons for https://github.com/weserv/images and I found this while I was experimenting with OpenResty and lua-vips. We plan to rewrite the complete code base to Lua because of the performance boost with LuaJIT versus PHP 7.

By the way,
I noticed that the LuaRocks version (1.1-5) is slightly behind (for e.g. it's missing the operation cache control functions). Can this be updated?