### PR TITLE
Avoid FFI sizeof trick and image copy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ local mem = image:write_to_memory()
 print("written ", ffi.sizeof(mem), "bytes to", mem)
 ```
 
-### `ptr, size = image:write_to_memory_nocopy()`
+### `ptr, size = image:write_to_memory_ptr()`
 
 An allocated char array pointer (GCd with a `ffi.gc` callback) and the length in bytes of the image data is directly returned from libvips (no intermediate FFI allocation).
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ local image = vips.Image.new_from_buffer(string, "shrink=2")
 
 Use (for example) `vips.Image.jpegload_buffer` to call a loader directly.
 
-### `image = vips.Image.new_from_memory(ptr, width, height, bands, format)`
+### `image = vips.Image.new_from_memory(data, width, height, bands, format)`
 
 This wraps a libvips image around a FFI memory array. The memory array should be
 formatted as a C-style array. Images are always band-interleaved, so an RGB
@@ -217,6 +217,12 @@ local im = vips.Image.new_from_memory(data, width, height, 1, "uchar")
 The returned image is using a pointer to the `data` area, but luajit won't
 always know this. You should keep a reference to `data` alive for as long as you
 are using any downstream images, or you'll get a crash.
+
+### `image = vips.Image.new_from_memory_ptr(data, size, width, height, bands, format)`
+
+Same as `new_from_memory`, but for any kind of data pointer (non-FFI allocated) by specifying the length of the data in bytes. The pointed data must be valid for the lifespan of the image and any downstream images.
+
+A string can be used as the data pointer thanks to LuaJIT FFI semantics.
 
 ### `image = vips.Image.new_from_image(image, pixel)`
 
@@ -512,6 +518,10 @@ A large ffi char array is allocated and the image is rendered to it.
 local mem = image:write_to_memory()
 print("written ", ffi.sizeof(mem), "bytes to", mem)
 ```
+
+### `ptr, size = image:write_to_memory_nocopy()`
+
+An allocated char array pointer (GCd with a `ffi.gc` callback) and the length in bytes of the image data is directly returned from libvips (no intermediate FFI allocation).
 
 ## Error handling
 

--- a/spec/new_spec.lua
+++ b/spec/new_spec.lua
@@ -177,7 +177,7 @@ describe("test image creation", function()
             local width = 64
             local height = 32
             local size = width * height
-            local data = ffi.gc(ffi.C.malloc(size), ffi.C.free)
+            local data = ffi.gc(ffi.cast("unsigned char*", ffi.C.malloc(size)), ffi.C.free)
 
             for y = 0, height - 1 do
                 for x = 0, width - 1 do

--- a/spec/new_spec.lua
+++ b/spec/new_spec.lua
@@ -1,4 +1,8 @@
 local ffi = require("ffi")
+ffi.cdef[[
+void* malloc(size_t size);
+void free(void *ptr);
+]]
 local vips = require "vips"
 
 -- test image new/load/etc.

--- a/spec/new_spec.lua
+++ b/spec/new_spec.lua
@@ -168,6 +168,28 @@ describe("test image creation", function()
             assert.are.equal(im:format(), "uchar")
             assert.are.equal(im:avg(), 47)
         end)
+
+        it("can make an image from a memory area (pointer)", function()
+            local width = 64
+            local height = 32
+            local size = width * height
+            local data = ffi.gc(ffi.C.malloc(size), ffi.C.free)
+
+            for y = 0, height - 1 do
+                for x = 0, width - 1 do
+                    data[x + y * width] = x + y
+                end
+            end
+
+            local im = vips.Image.new_from_memory_ptr(data,
+                size, width, height, 1, "uchar")
+
+            assert.are.equal(im:width(), width)
+            assert.are.equal(im:height(), height)
+            assert.are.equal(im:bands(), 1)
+            assert.are.equal(im:format(), "uchar")
+            assert.are.equal(im:avg(), 47)
+        end)
     end)
 
     describe("test vips creators", function()

--- a/spec/write_spec.lua
+++ b/spec/write_spec.lua
@@ -83,14 +83,14 @@ describe("test image write", function()
 
         it("can write an image to a memory area (no copy)", function()
             local im = vips.Image.new_from_file("./spec/images/Gugg_coloured.jpg")
-            local ptr, size = im:write_to_memory_nocopy()
+            local ptr, size = im:write_to_memory_ptr()
 
             assert.are.equal(im:width() * im:height() * 3, size)
         end)
 
         it("can read an image back from a memory area (no copy)", function()
             local im = vips.Image.new_from_file("./spec/images/Gugg_coloured.jpg")
-            local ptr, size = im:write_to_memory_nocopy()
+            local ptr, size = im:write_to_memory_ptr()
             assert.are.equal(im:width() * im:height() * 3, size)
             local im2 = vips.Image.new_from_memory_ptr(ptr,
                 size, im:width(), im:height(), im:bands(), im:format())

--- a/spec/write_spec.lua
+++ b/spec/write_spec.lua
@@ -80,6 +80,23 @@ describe("test image write", function()
 
             assert.are.equal(im:avg(), im2:avg())
         end)
+
+        it("can write an image to a memory area (no copy)", function()
+            local im = vips.Image.new_from_file("./spec/images/Gugg_coloured.jpg")
+            local ptr, size = im:write_to_memory_nocopy()
+
+            assert.are.equal(im:width() * im:height() * 3, size)
+        end)
+
+        it("can read an image back from a memory area (no copy)", function()
+            local im = vips.Image.new_from_file("./spec/images/Gugg_coloured.jpg")
+            local ptr, size = im:write_to_memory_nocopy()
+            assert.are.equal(im:width() * im:height() * 3, size)
+            local im2 = vips.Image.new_from_memory_ptr(ptr,
+                size, im:width(), im:height(), im:bands(), im:format())
+
+            assert.are.equal(im:avg(), im2:avg())
+        end)
     end)
 
     describe("MODIFY args", function()

--- a/spec/write_spec.lua
+++ b/spec/write_spec.lua
@@ -83,7 +83,7 @@ describe("test image write", function()
 
         it("can write an image to a memory area (no copy)", function()
             local im = vips.Image.new_from_file("./spec/images/Gugg_coloured.jpg")
-            local ptr, size = im:write_to_memory_ptr()
+            local _, size = im:write_to_memory_ptr()
 
             assert.are.equal(im:width() * im:height() * 3, size)
         end)

--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -158,22 +158,21 @@ function Image.new_from_buffer(data, options, ...)
     return voperation.call(name, options or "", data, unpack { ... })
 end
 
-function Image.new_from_memory(data, width, height, bands, format)
+function Image.new_from_memory_ptr(data, size, width, height, bands, format)
     local format_value = gvalue.to_enum(gvalue.band_format_type, format)
-    local size = ffi.sizeof(data)
-
     local vimage = vips_lib.vips_image_new_from_memory(data, size,
         width, height, bands, format_value)
     if vimage == nil then
         error(verror.get())
     end
+    return Image.new(vimage)
+end
 
-    local image = Image.new(vimage)
-
+function Image.new_from_memory(data, width, height, bands, format)
+    local image = Image.new_from_memory_ptr(data, ffi.sizeof(data), width, height, bands, format)
     -- libvips is using the memory we passed in: save a pointer to the memory
     -- block to try to stop it being GCd
     image._data = data
-
     return image
 end
 
@@ -388,12 +387,19 @@ function Image_method:write_to_memory()
     local psize = ffi.new(gvalue.psize_typeof, 1)
     local vips_memory = vips_lib.vips_image_write_to_memory(self.vimage, psize)
     local size = psize[0]
-    -- FIXME can we avoid the copy somehow?
+
     local lua_memory = ffi.new(gvalue.mem_typeof, size)
     ffi.copy(lua_memory, vips_memory, size)
     glib_lib.g_free(vips_memory)
 
     return lua_memory
+end
+
+function Image_method:write_to_memory_nocopy()
+    local psize = ffi.new(gvalue.psize_typeof, 1)
+    local vips_memory = vips_lib.vips_image_write_to_memory(self.vimage, psize)
+
+    return ffi.gc(vips_memory, glib_lib.g_free), psize[0]
 end
 
 -- get/set metadata

--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -395,7 +395,7 @@ function Image_method:write_to_memory()
     return lua_memory
 end
 
-function Image_method:write_to_memory_nocopy()
+function Image_method:write_to_memory_ptr()
     local psize = ffi.new(gvalue.psize_typeof, 1)
     local vips_memory = vips_lib.vips_image_write_to_memory(self.vimage, psize)
 


### PR DESCRIPTION
> Not all pointers "carry" the size of the memory they point on (just like
in C), thus it was restricting the usage to LuaJIT allocated memory
(which can be confusing and has limitations without the GC64 mode).

> Note: this way even allows a string to be passed as the data pointer.

Hi, I was using lua-vips for processing and I encountered this limitation. FFI is low level, so it makes sense to not abstract away the pointer/size.

 (I edited _example/array.lua_ by mistake, fixed it, but the pull request is not updated)