### PR TITLE
Throw a more informative error on invalid flag

### DIFF
--- a/src/vips/voperation.lua
+++ b/src/vips/voperation.lua
@@ -220,7 +220,13 @@ voperation.call = function(name, string_options, ...)
 
     if last_arg then
         for k, v in pairs(last_arg) do
-            if not vop:set(k, flags_from_name[k], match_image, v) then
+            local flag = flags_from_name[k]
+            if not flag then
+                error("unable to call " .. name .. ": invalid flag '" ..
+                        tostring(k) .. "'")
+            end
+
+            if not vop:set(k, flag, match_image, v) then
                 error("unable to call " .. name .. "\n" .. verror.get())
             end
         end


### PR DESCRIPTION
Passing an invalid flag to an operation throws a very uninformative `bad argument #1 to 'band' (number expected, got nil)` error. This PR checks for invalid flags and throws a much cleaner error, detailing the name of the invalid flag. As an example, calling `flatten` with `"nonsense"` as a flag would result in `unable to call operation flatten: invalid flag 'nonsense'`.