### PR TITLE
Add bindings for misc image methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `lua-vips` will be documented in this file.
 # master
 
 - add `vips.concurrency_get()` and `set()` [kamyabzad]
+- add `hasalpha`/`addalpha` [RiskoZoSlovenska]
 
 # 1.1-10 - 2021-04-18
 
@@ -66,4 +67,3 @@ All notable changes to `lua-vips` will be documented in this file.
 # 1.0-1 - 2017-06-04
 
 - first API stable release
-

--- a/spec/convenience_spec.lua
+++ b/spec/convenience_spec.lua
@@ -117,5 +117,16 @@ describe("test convenience functions", function()
         assert.are.equal(result:bands(), 1)
         assert.are.equal(result:avg(), 17 / 4)
     end)
-end)
 
+    it("can call hasalpha", function()
+        local im1 = vips.Image.new_from_file("./spec/images/Gugg_coloured.jpg")
+        local im2 = vips.Image.new_from_file("./spec/images/watermark.png")
+
+        assert.is_false(im1:hasalpha())
+        assert.is_true(im2:hasalpha())
+    end)
+
+    it("can call addalpha", function ()
+        assert.are.equal(im:addalpha():avg(), 128.75)
+    end)
+end)

--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -575,6 +575,28 @@ end
 
 -- convenience functions
 
+function Image_method:hasalpha()
+    local result = vips_lib.vips_image_hasalpha(self.vimage)
+    if result == nil then
+        error(verror.get())
+    end
+
+    return result ~= 0
+end
+
+function Image_method:addalpha()
+    local max_alpha
+    if self:interpretation() == "rgb16" or self:interpretation() == "grey16" then
+        max_alpha = 65535
+    elseif self:interpretation() == "scrgb" then
+        max_alpha = 1.0
+    else
+        max_alpha = 255
+    end
+
+    return self:bandjoin(max_alpha)
+end
+
 function Image_method:bandsplit()
     local result
 

--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -576,12 +576,7 @@ end
 -- convenience functions
 
 function Image_method:hasalpha()
-    local result = vips_lib.vips_image_hasalpha(self.vimage)
-    if result == nil then
-        error(verror.get())
-    end
-
-    return result ~= 0
+    return vips_lib.vips_image_hasalpha(self.vimage) ~= 0
 end
 
 function Image_method:addalpha()

--- a/src/vips/cdefs.lua
+++ b/src/vips/cdefs.lua
@@ -177,6 +177,8 @@ ffi.cdef [[
     void vips_image_set (VipsImage *image, const char *name, GValue *value);
     int vips_image_remove (VipsImage *image, const char *name);
 
+    int vips_image_hasalpha(VipsImage *image);
+
     char *vips_filename_get_filename (const char *vips_filename);
     char *vips_filename_get_options (const char *vips_filename);
 


### PR DESCRIPTION
This PR adds support for a small handful of misc image methods which are not covered by the binding, such as `hasalpha`.

Since vips is still a bit of a black box for me, I'm not 100% sure that this is the correct way to add support for these methods, but it looks like [pyvips does the same thing](https://github.com/libvips/pyvips/blob/a6d622957743f6f015a51e6b80fdbeccc85b44ae/pyvips/vimage.py#L1429).

I'm not sure whether tests are necessary here, and if they are, I'm not sure where to put them.