### PR TITLE
Add example error messages

### DIFF
--- a/example/buffer.lua
+++ b/example/buffer.lua
@@ -8,7 +8,7 @@ if #arg ~= 1 then
     print("usage: luajit buffer.lua image-file")
     error()
 end
-local f = io.open(arg[1], "rb")
+local f = assert(io.open(arg[1], "rb"))
 local content = f:read("*all")
 
 local im = vips.Image.new_from_buffer(content, "", {access = "sequential"})

--- a/example/buffer.lua
+++ b/example/buffer.lua
@@ -4,6 +4,10 @@
 
 local vips = require "vips"
 
+if #arg ~= 1 then
+    print("usage: luajit buffer.lua image-file")
+    error()
+end
 local f = io.open(arg[1], "rb")
 local content = f:read("*all")
 

--- a/example/watermark.lua
+++ b/example/watermark.lua
@@ -8,6 +8,10 @@ local vips = require "vips"
 -- uncomment for very chatty output
 -- vips.log.enable(true)
 
+if #arg ~= 3 then
+    print("usage: luajit watermark.lua input-image-file output-image-file text")
+    error()
+end
 local im = vips.Image.new_from_file(arg[1], {access = "sequential"})
 
 -- make the text mask


### PR DESCRIPTION
Make the examples more user friendly by printing error messages when invoked wrongly.