### PR TITLE
Use Lua `addalpha` implementation only for libvips < 8.16.0

### DIFF
--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -579,17 +579,20 @@ function Image_method:hasalpha()
     return vips_lib.vips_image_hasalpha(self.vimage) ~= 0
 end
 
-function Image_method:addalpha()
-    local max_alpha
-    if self:interpretation() == "rgb16" or self:interpretation() == "grey16" then
-        max_alpha = 65535
-    elseif self:interpretation() == "scrgb" then
-        max_alpha = 1.0
-    else
-        max_alpha = 255
-    end
+-- addalpha was made a VipsOperation in vips 8.16; earlier versions need this polyfill
+if not version.at_least(8, 16) then
+    function Image_method:addalpha()
+        local max_alpha
+        if self:interpretation() == "rgb16" or self:interpretation() == "grey16" then
+            max_alpha = 65535
+        elseif self:interpretation() == "scrgb" then
+            max_alpha = 1.0
+        else
+            max_alpha = 255
+        end
 
-    return self:bandjoin(max_alpha)
+        return self:bandjoin(max_alpha)
+    end
 end
 
 function Image_method:bandsplit()


### PR DESCRIPTION
As of this writing, the master branch of libvips supports `addalpha` as an operation (see https://github.com/libvips/libvips/pull/3884), meaning that the native Lua implementation is unnecessary.

It will probably be best to wait until libvips 8.16 is released before merging this since there is no 100% guarantee that the change will actually make it to 8.16.