### PR TITLE
Add bitops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.3", "5.4", "luajit-2.1.0-beta3", "luajit-openresty"]
+        luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit-2.1.0-beta3", "luajit-openresty"]
 
     steps:
     - uses: actions/checkout@v4
@@ -28,6 +28,9 @@ jobs:
       run: |
         make dev
         if [[ ${{ matrix.luaVersion }} == 5.* ]]; then make ffi; fi
+        if [[ ${{ matrix.luaVersion }} == 5.1 ]] || [[ ${{ matrix.luaVersion }} == 5.2 ]]; then
+          make bit 
+        fi
 
     - name: Lint with luacheck
       run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DEV_ROCKS = "busted 2.2.0" "luacheck 1.1.2"
 BUSTED_ARGS ?= -o gtest -v
 TEST_CMD ?= busted $(BUSTED_ARGS)
 
-.PHONY: dev ffi lint test
+.PHONY: dev ffi bit lint test
 
 dev:
 	@for rock in $(DEV_ROCKS) ; do \
@@ -16,6 +16,9 @@ dev:
 
 ffi:
 	@luarocks install luaffi-tkl
+
+bit:
+	@luarocks install luabitop
 
 lint:
 	@luacheck -q .

--- a/lua-vips-1.1-10.rockspec
+++ b/lua-vips-1.1-10.rockspec
@@ -24,6 +24,7 @@ build = {
    type = "builtin",
    modules = {
        vips = "src/vips.lua",
+       ["vips.bitops"] = "src/vips/bitops.lua",
        ["vips.cdefs"] = "src/vips/cdefs.lua",
        ["vips.verror"] = "src/vips/verror.lua",
        ["vips.version"] = "src/vips/version.lua",

--- a/src/vips/bitops.lua
+++ b/src/vips/bitops.lua
@@ -1,0 +1,21 @@
+local hasbit, bit = pcall(require, "bit")
+local bitops = {}
+
+if hasbit then -- Lua 5.1, 5.2 with luabitop or LuaJIT
+    bitops.band = bit.band
+elseif (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
+    error("Bit operations missing. Please install 'luabitop'")
+else -- Lua >= 5.3
+    local band, err = load("return function(a, b) return a & b end")
+    if band then
+        local ok
+        ok, bitops.band = pcall(band)
+        if not ok then
+            error("Execution error")
+        end
+    else
+        error("Compilation error" .. err)
+    end
+end
+
+return bitops

--- a/src/vips/voperation.lua
+++ b/src/vips/voperation.lua
@@ -2,8 +2,8 @@
 -- lookup and call operations
 
 local ffi = require "ffi"
-local bit = require "bit"
 
+local bitops = require "vips.bitops"
 local verror = require "vips.verror"
 local version = require "vips.version"
 local log = require "vips.log"
@@ -11,7 +11,7 @@ local gvalue = require "vips.gvalue"
 local vobject = require "vips.vobject"
 local Image = require "vips.Image"
 
-local band = bit.band
+local band = bitops.band
 local type = type
 local error = error
 local pairs = pairs


### PR DESCRIPTION
`luaffi-tkl`, which is used on Lua 5.x to replace the LuaJIT builtin `ffi` module, has dropped shipping its `bit`-module (which only worked on Lua >= 5.3). This PR replaces the `bit`-module via `bitops.lua`. Only the bitwise and on two arguments is needed.


For LuaJIT: use builtin bit.band
For Lua 5.1, 5.2: use bit.band from luabitop if available
For Lua 5.3, 5.4: use builtin & operator


On Lua 5.1, 5.2, which are newly supported, `luabitop` becomes a dependency.