### PR TITLE
Add interpolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `lua-vips` will be documented in this file.
 
 # master
 
+- add `vips.Interpolate` [jcupitt, rolandlo]
 - add `vips.concurrency_get()` and `set()` [kamyabzad]
 - add `hasalpha`/`addalpha` [RiskoZoSlovenska]
 

--- a/lua-vips-1.1-10.rockspec
+++ b/lua-vips-1.1-10.rockspec
@@ -33,6 +33,7 @@ build = {
        ["vips.vobject"] = "src/vips/vobject.lua",
        ["vips.voperation"] = "src/vips/voperation.lua",
        ["vips.Image"] = "src/vips/Image.lua",
-       ["vips.Image_methods"] = "src/vips/Image_methods.lua"
+       ["vips.Image_methods"] = "src/vips/Image_methods.lua",
+       ["vips.Interpolate"] = "src/vips/Interpolate.lua"
    }
 }

--- a/spec/interpolate_spec.lua
+++ b/spec/interpolate_spec.lua
@@ -7,7 +7,7 @@ describe("image interpolation", function()
     end)
 
     it("can rotate an image using nearest interpolator", function()
-        local interpolate = vips.Interpolate.new_from_name("nearest")
+        local interpolate = vips.Interpolate.new("nearest")
         local original = {
             { 1, 2, 3 },
             { 4, 5, 6 },

--- a/spec/interpolate_spec.lua
+++ b/spec/interpolate_spec.lua
@@ -1,0 +1,33 @@
+local vips = require "vips"
+
+-- test image interpolation
+describe("image interpolation", function()
+    setup(function()
+        -- vips.log.enable(true)
+    end)
+
+    it("can rotate an image using nearest interpolator", function()
+        local interpolate = vips.Interpolate.new_from_name("nearest")
+        local original = {
+            { 1, 2, 3 },
+            { 4, 5, 6 },
+            { 7, 8, 9 },
+        }
+        local rotated = {
+            { 0.0, 0.0, 1.0, 0.0 },
+            { 0.0, 0.0, 1.0, 2.0 },
+            { 0.0, 7.0, 5.0, 3.0 },
+            { 0.0, 8.0, 9.0, 6.0 }
+        }
+        local im = vips.Image.new_from_array(original)
+        local rot = im:rotate(45, { interpolate = interpolate })
+        assert.are.equal(rot:width(), 4)
+        assert.are.equal(rot:height(), 4)
+        assert.are.equal(rot:bands(), 1)
+        for x = 1, 4 do
+            for y = 1, 4 do
+                assert.are_equal(rot(x - 1, y - 1), rotated[y][x])
+            end
+        end
+    end)
+end)

--- a/src/vips.lua
+++ b/src/vips.lua
@@ -22,7 +22,7 @@ local vips = {
     vobject = require "vips.vobject",
     voperation = require "vips.voperation",
     Image = require "vips.Image_methods",
-    Image = require "vips.Interpolate",
+    Interpolate = require "vips.Interpolate",
 }
 
 function vips.leak_set(leak)

--- a/src/vips.lua
+++ b/src/vips.lua
@@ -22,6 +22,7 @@ local vips = {
     vobject = require "vips.vobject",
     voperation = require "vips.voperation",
     Image = require "vips.Image_methods",
+    Image = require "vips.Interpolate",
 }
 
 function vips.leak_set(leak)

--- a/src/vips/Interpolate.lua
+++ b/src/vips/Interpolate.lua
@@ -13,18 +13,14 @@ Interpolate.vobject = function(self)
     return ffi.cast(vobject.typeof, self)
 end
 
-Interpolate.new = function(self)
-    return vobject.new(self)
-end
-
-Interpolate.new_from_name = function(name)
+Interpolate.new = function(name)
     -- there could potentially be other params here, but ignore that for now
     local interpolate = vips_lib.vips_interpolate_new(name)
     if interpolate == nil then
         error("no such interpolator\n" .. verror.get())
     end
 
-    return Interpolate.new(interpolate)
+    return vobject.new(interpolate)
 end
 
 return ffi.metatype("VipsInterpolate", {

--- a/src/vips/Interpolate.lua
+++ b/src/vips/Interpolate.lua
@@ -27,7 +27,7 @@ Interpolate.new_from_name = function(name)
     return Interpolate.new(interpolate)
 end
 
-return ffi.metatype("Interpolate", {
+return ffi.metatype("VipsInterpolate", {
     __index = Interpolate
 })
 

--- a/src/vips/Interpolate.lua
+++ b/src/vips/Interpolate.lua
@@ -1,0 +1,34 @@
+-- make image interpolators, see affine
+
+local ffi = require "ffi"
+
+local verror = require "vips.verror"
+local vobject = require "vips.vobject"
+
+local vips_lib = ffi.load(ffi.os == "Windows" and "libvips-42.dll" or "vips")
+
+local Interpolate = {}
+
+Interpolate.vobject = function(self)
+    return ffi.cast(vobject.typeof, self)
+end
+
+Interpolate.new = function(self)
+    return vobject.new(self)
+end
+
+Interpolate.new_from_name = function(name)
+    -- there could potentially be other params here, but ignore that for now
+    local interpolate = vips_lib.vips_interpolate_new(name)
+    if interpolate == nil then
+        error("no such interpolator\n" .. verror.get())
+    end
+
+    return Interpolate.new(interpolate)
+end
+
+return ffi.metatype("Interpolate", {
+    __index = Interpolate
+})
+
+

--- a/src/vips/cdefs.lua
+++ b/src/vips/cdefs.lua
@@ -188,6 +188,8 @@ ffi.cdef [[
         // opaque
     } VipsOperation;
 
+    VipsInterpolate *vips_interpolate_new (const char *name);
+
     VipsOperation *vips_operation_new (const char *name);
 
     typedef void * (*VipsArgumentMapFn) (VipsOperation *object,

--- a/src/vips/cdefs.lua
+++ b/src/vips/cdefs.lua
@@ -188,6 +188,12 @@ ffi.cdef [[
         // opaque
     } VipsOperation;
 
+    typedef struct _VipsInterpolate {
+        VipsObject parent_instance;
+
+        // opaque
+    } VipsInterpolate;
+
     VipsInterpolate *vips_interpolate_new (const char *name);
 
     VipsOperation *vips_operation_new (const char *name);

--- a/src/vips/gvalue.lua
+++ b/src/vips/gvalue.lua
@@ -39,6 +39,7 @@ gvalue.int_arr_typeof = ffi.typeof("const int[?]")
 gvalue.double_arr_typeof = ffi.typeof("const double[?]")
 gvalue.psize_typeof = ffi.typeof("size_t[?]")
 gvalue.mem_typeof = ffi.typeof("unsigned char[?]")
+gvalue.interpolate_typeof = ffi.typeof("VipsInterpolate*")
 
 -- look up some common gtypes at init for speed
 gvalue.gbool_type = gobject_lib.g_type_from_name("gboolean")
@@ -55,6 +56,7 @@ gvalue.refstr_type = gobject_lib.g_type_from_name("VipsRefString")
 gvalue.blob_type = gobject_lib.g_type_from_name("VipsBlob")
 gvalue.band_format_type = gobject_lib.g_type_from_name("VipsBandFormat")
 gvalue.blend_mode_type = version.at_least(8, 6) and gobject_lib.g_type_from_name("VipsBlendMode") or 0
+gvalue.interpolate_type = gobject_lib.g_type_from_name("VipsInterpolate")
 
 -- gvalue.*_type can be of type cdata or number depending on the OS and Lua version
 -- gtypes as returned by vips_lib can also be of type cdata or number
@@ -155,6 +157,8 @@ gvalue.set = function(gv, value)
         else
             vips_lib.vips_value_set_blob(gv, glib_lib.g_free, buf, n)
         end
+    elseif gtype_comp == gvalue.interpolate_type then
+        gobject_lib.g_value_set_object(gv, value)
     else
         error("unsupported gtype for set " .. gvalue.type_name(gtype))
     end
@@ -249,6 +253,9 @@ gvalue.get = function(gv)
         local array = vips_lib.vips_value_get_blob(gv, psize)
 
         result = ffi.string(array, tonumber(psize[0]))
+    elseif gtype_comp == gvalue.interpolate_type then
+        local vo = gobject_lib.g_value_get_object(gv)
+        result = ffi.cast(gvalue.interpolate_typeof, vo)
     else
         error("unsupported gtype for get " .. gvalue.type_name(gtype))
     end


### PR DESCRIPTION
Fixes #57

@jcupitt I renamed `Interpolate.new_from_name` to `Interpolate.new` in accordance with `pyvips` and the name `vips_interpolate_new`. Or is there a point in using a different name like `Interpolate.new_from_name`?

By the way the test suite now runs successfully on all of 5.1, 5.2, 5.3, 5.4, luajit-2.1.0-beta3 and luajit-openresty (on Ubuntu). All versions are tested on push and pull-request.