### PR TITLE
Add testing for MacOs and Windows and fix Windows issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: "Unix build"
+name: "CI"
 
 on: [push, pull_request]
 
 jobs:
-  test:
+  unix:
     strategy:
       fail-fast: false
       matrix:
@@ -39,8 +39,71 @@ jobs:
 
     - name: Lint with luacheck
       run: |
-        make lint
+        luacheck -q .
 
     - name: Busted tests
       run: |
-        make test
+        busted -o gtest -v spec
+
+
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        lua: [
+              #{name: "lua51", exe: "lua5.1", version: 5.1, incdir: "/mingw64/include/lua5.1/"},  #(two tests are failing)
+              {name: "lua53", exe: "lua5.3", version: 5.3, incdir: "/mingw64/include/lua5.3/"},
+              {name: "lua", exe: "lua", version: 5.4, incdir: "/mingw64/include/"},
+              {name: "luajit", exe: "luajit", version: 5.1, incdir: "/mingw64/include/luajit-2.1/"}
+             ]
+
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: git
+                   make
+                   mingw-w64-x86_64-toolchain
+                   mingw-w64-x86_64-libvips
+                   mingw-w64-x86_64-openslide
+                   mingw-w64-x86_64-libheif
+                   mingw-w64-x86_64-libjxl
+                   mingw-w64-x86_64-imagemagick
+                   mingw-w64-x86_64-poppler
+                   mingw-w64-x86_64-lua-luarocks
+                   mingw-w64-x86_64-${{ matrix.lua.name }}
+
+      - if: matrix.lua.name == 'lua51'
+        name: Install bitop
+        run: |
+          pacman --noconfirm -S mingw-w64-x86_64-lua51-bitop
+
+      - name: Lua dependencies
+        run: |
+          if [[ ${{ matrix.lua.exe }} == lua5.3 ]]; then
+            cp /mingw64/etc/luarocks/config-5.{4,3}.lua
+          fi
+          luarocks config --scope system lua_version ${{ matrix.lua.version }}
+          luarocks config --scope system lua_interpreter ${{ matrix.lua.exe }}.exe
+          luarocks config --scope system variables.LUA_DIR /mingw64/bin
+          luarocks config --scope system variables.LUA_INCDIR ${{ matrix.lua.incdir }}
+          make dev
+          if [[ ${{ matrix.lua.exe }} != luajit ]]; then make ffi; fi
+
+      - name: Add to PATH
+        run: |
+          echo $RUNNER_TEMP/msys64/mingw64/bin:$HOME/.luarocks/bin >> $GITHUB_PATH
+
+      - name: Lint with luacheck
+        run: |
+          luacheck.bat -q .
+
+      - name: Busted tests
+        run: |
+          busted.bat --lua=${{ matrix.lua.exe }} -o gtest -v spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
         luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit-2.1.0-beta3", "luajit-openresty"]
+        os: ["ubuntu-latest", "macos-latest"]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
@@ -22,7 +23,11 @@ jobs:
 
     - name: Install libvips
       run: |
-        sudo apt install --no-install-recommends libvips-dev
+        if [[ ${{ matrix.os }} == macos* ]]; then
+          brew install vips
+        elif [[ ${{ matrix.os }} == ubuntu* ]]; then
+          sudo apt install --no-install-recommends libvips-dev
+        fi
 
     - name: Lua dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 DEV_ROCKS = "busted 2.2.0" "luacheck 1.1.2"
-BUSTED_ARGS ?= -o gtest -v
-TEST_CMD ?= busted $(BUSTED_ARGS)
 
-.PHONY: dev ffi bit lint test
+.PHONY: dev ffi bit
 
 dev:
 	@for rock in $(DEV_ROCKS) ; do \
@@ -19,9 +17,3 @@ ffi:
 
 bit:
 	@luarocks install luabitop
-
-lint:
-	@luacheck -q .
-
-test:
-	@$(TEST_CMD) spec/

--- a/spec/meta_spec.lua
+++ b/spec/meta_spec.lua
@@ -1,9 +1,10 @@
 local vips = require "vips"
+local ffi = require "ffi"
 
 -- test metadata read/write
 describe("metadata", function()
     local array, im
-    local tmp_vips_filename = "/tmp/x.v"
+    local tmp_vips_filename = ffi.os == "Windows" and os.getenv("TMP") .. "\\x.v" or "/tmp/x.v"
 
     setup(function()
         array = { 1, 2, 3, 4 }

--- a/spec/write_spec.lua
+++ b/spec/write_spec.lua
@@ -11,8 +11,8 @@ describe("test image write", function()
     describe("to file", function()
         local array = { 1, 2, 3, 4 }
         local im = vips.Image.new_from_array(array)
-        local tmp_png_filename = "/tmp/x.png"
-        local tmp_jpg_filename = "/tmp/x.jpg"
+        local tmp_png_filename = ffi.os == "Windows" and os.getenv("TMP") .. "\\x.png" or "/tmp/x.png"
+        local tmp_jpg_filename = ffi.os == "Windows" and os.getenv("TMP") .. "\\x.jpg" or "/tmp/x.jpg"
 
         teardown(function()
             os.remove(tmp_png_filename)

--- a/src/vips/gvalue.lua
+++ b/src/vips/gvalue.lua
@@ -56,6 +56,12 @@ gvalue.blob_type = gobject_lib.g_type_from_name("VipsBlob")
 gvalue.band_format_type = gobject_lib.g_type_from_name("VipsBandFormat")
 gvalue.blend_mode_type = version.at_least(8, 6) and gobject_lib.g_type_from_name("VipsBlendMode") or 0
 
+-- gvalue.*_type can be of type cdata or number depending on the OS and Lua version
+-- gtypes as returned by vips_lib can also be of type cdata or number
+-- cdata and number are not comparable with Standard Lua (using luaffi-tkl)
+gvalue.comparable_type = type(gvalue.gdouble_type) == "number" and
+    function(gtype) return tonumber(gtype) end or
+    function(gtype) return gtype end
 gvalue.to_enum = function(gtype, value)
     -- turn a string into an int, ready to be passed into libvips
     local enum_value
@@ -84,7 +90,7 @@ end
 
 gvalue.set = function(gv, value)
     local gtype_raw = gv.gtype
-    local gtype = tonumber(gtype_raw)
+    local gtype = gvalue.comparable_type(gtype_raw)
     local fundamental = gobject_lib.g_type_fundamental(gtype_raw)
 
     if gtype == gvalue.gbool_type then
@@ -156,7 +162,7 @@ end
 
 gvalue.get = function(gv)
     local gtype_raw = gv.gtype
-    local gtype = tonumber(gtype_raw)
+    local gtype = gvalue.comparable_type(gtype_raw)
     local fundamental = gobject_lib.g_type_fundamental(gtype_raw)
 
     local result

--- a/src/vips/gvalue.lua
+++ b/src/vips/gvalue.lua
@@ -89,27 +89,27 @@ gvalue.init = function(gv, gtype)
 end
 
 gvalue.set = function(gv, value)
-    local gtype_raw = gv.gtype
-    local gtype = gvalue.comparable_type(gtype_raw)
-    local fundamental = gobject_lib.g_type_fundamental(gtype_raw)
+    local gtype = gv.gtype
+    local gtype_comp = gvalue.comparable_type(gtype)
+    local fundamental = gobject_lib.g_type_fundamental(gtype)
 
-    if gtype == gvalue.gbool_type then
+    if gtype_comp == gvalue.gbool_type then
         gobject_lib.g_value_set_boolean(gv, value)
-    elseif gtype == gvalue.gint_type then
+    elseif gtype_comp == gvalue.gint_type then
         gobject_lib.g_value_set_int(gv, value)
-    elseif gtype == gvalue.gdouble_type then
+    elseif gtype_comp == gvalue.gdouble_type then
         gobject_lib.g_value_set_double(gv, value)
     elseif fundamental == gvalue.genum_type then
-        gobject_lib.g_value_set_enum(gv, gvalue.to_enum(gtype_raw, value))
+        gobject_lib.g_value_set_enum(gv, gvalue.to_enum(gtype, value))
     elseif fundamental == gvalue.gflags_type then
         gobject_lib.g_value_set_flags(gv, value)
-    elseif gtype == gvalue.gstr_type then
+    elseif gtype_comp == gvalue.gstr_type then
         gobject_lib.g_value_set_string(gv, value)
-    elseif gtype == gvalue.refstr_type then
+    elseif gtype_comp == gvalue.refstr_type then
         gobject_lib.vips_value_set_ref_string(gv, value)
-    elseif gtype == gvalue.image_type then
+    elseif gtype_comp == gvalue.image_type then
         gobject_lib.g_value_set_object(gv, value.vimage)
-    elseif gtype == gvalue.array_int_type then
+    elseif gtype_comp == gvalue.array_int_type then
         if type(value) == "number" then
             value = { value }
         end
@@ -118,7 +118,7 @@ gvalue.set = function(gv, value)
         local a = ffi.new(gvalue.int_arr_typeof, n, value)
 
         vips_lib.vips_value_set_array_int(gv, a, n)
-    elseif gtype == gvalue.array_double_type then
+    elseif gtype_comp == gvalue.array_double_type then
         if type(value) == "number" then
             value = { value }
         end
@@ -127,7 +127,7 @@ gvalue.set = function(gv, value)
         local a = ffi.new(gvalue.double_arr_typeof, n, value)
 
         vips_lib.vips_value_set_array_double(gv, a, n)
-    elseif gtype == gvalue.array_image_type then
+    elseif gtype_comp == gvalue.array_image_type then
         if Image.is_Image(value) then
             value = { value }
         end
@@ -142,7 +142,7 @@ gvalue.set = function(gv, value)
             -- the gvalue needs a set of refs to own
             gobject_lib.g_object_ref(a[i])
         end
-    elseif gtype == gvalue.blob_type then
+    elseif gtype_comp == gvalue.blob_type then
         -- we need to set the blob to a copy of the lua string that vips
         -- can own
         local n = #value
@@ -156,27 +156,27 @@ gvalue.set = function(gv, value)
             vips_lib.vips_value_set_blob(gv, glib_lib.g_free, buf, n)
         end
     else
-        error("unsupported gtype for set " .. gvalue.type_name(gtype_raw))
+        error("unsupported gtype for set " .. gvalue.type_name(gtype))
     end
 end
 
 gvalue.get = function(gv)
-    local gtype_raw = gv.gtype
-    local gtype = gvalue.comparable_type(gtype_raw)
-    local fundamental = gobject_lib.g_type_fundamental(gtype_raw)
+    local gtype = gv.gtype
+    local gtype_comp = gvalue.comparable_type(gtype)
+    local fundamental = gobject_lib.g_type_fundamental(gtype)
 
     local result
 
-    if gtype == gvalue.gbool_type then
+    if gtype_comp == gvalue.gbool_type then
         result = gobject_lib.g_value_get_boolean(gv)
-    elseif gtype == gvalue.gint_type then
+    elseif gtype_comp == gvalue.gint_type then
         result = gobject_lib.g_value_get_int(gv)
-    elseif gtype == gvalue.gdouble_type then
+    elseif gtype_comp == gvalue.gdouble_type then
         result = gobject_lib.g_value_get_double(gv)
     elseif fundamental == gvalue.genum_type then
         local enum_value = gobject_lib.g_value_get_enum(gv)
 
-        local cstr = vips_lib.vips_enum_nick(gtype_raw, enum_value)
+        local cstr = vips_lib.vips_enum_nick(gtype, enum_value)
 
         if cstr == ffi.NULL then
             error("value not in enum")
@@ -185,7 +185,7 @@ gvalue.get = function(gv)
         result = ffi.string(cstr)
     elseif fundamental == gvalue.gflags_type then
         result = gobject_lib.g_value_get_flags(gv)
-    elseif gtype == gvalue.gstr_type then
+    elseif gtype_comp == gvalue.gstr_type then
         local cstr = gobject_lib.g_value_get_string(gv)
 
         if cstr ~= ffi.NULL then
@@ -193,13 +193,13 @@ gvalue.get = function(gv)
         else
             result = nil
         end
-    elseif gtype == gvalue.refstr_type then
+    elseif gtype_comp == gvalue.refstr_type then
         local psize = ffi.new(gvalue.psize_typeof, 1)
 
         local cstr = vips_lib.vips_value_get_ref_string(gv, psize)
 
         result = ffi.string(cstr, tonumber(psize[0]))
-    elseif gtype == gvalue.image_type then
+    elseif gtype_comp == gvalue.image_type then
         -- g_value_get_object() will not add a ref ... that is
         -- held by the gvalue
         local vo = gobject_lib.g_value_get_object(gv)
@@ -211,7 +211,7 @@ gvalue.get = function(gv)
         gobject_lib.g_object_ref(vimage)
 
         result = Image.new(vimage)
-    elseif gtype == gvalue.array_int_type then
+    elseif gtype_comp == gvalue.array_int_type then
         local pint = ffi.new(gvalue.pint_typeof, 1)
 
         local array = vips_lib.vips_value_get_array_int(gv, pint)
@@ -220,7 +220,7 @@ gvalue.get = function(gv)
             result[i + 1] = array[i]
         end
 
-    elseif gtype == gvalue.array_double_type then
+    elseif gtype_comp == gvalue.array_double_type then
         local pint = ffi.new(gvalue.pint_typeof, 1)
 
         local array = vips_lib.vips_value_get_array_double(gv, pint)
@@ -228,7 +228,7 @@ gvalue.get = function(gv)
         for i = 0, pint[0] - 1 do
             result[i + 1] = array[i]
         end
-    elseif gtype == gvalue.array_image_type then
+    elseif gtype_comp == gvalue.array_image_type then
         local pint = ffi.new(gvalue.pint_typeof, 1)
 
         local array = vips_lib.vips_value_get_array_image(gv, pint)
@@ -243,14 +243,14 @@ gvalue.get = function(gv)
 
             result[i + 1] = Image.new(vimage)
         end
-    elseif gtype == gvalue.blob_type then
+    elseif gtype_comp == gvalue.blob_type then
         local psize = ffi.new(gvalue.psize_typeof, 1)
 
         local array = vips_lib.vips_value_get_blob(gv, psize)
 
         result = ffi.string(array, tonumber(psize[0]))
     else
-        error("unsupported gtype for get " .. gvalue.type_name(gtype_raw))
+        error("unsupported gtype for get " .. gvalue.type_name(gtype))
     end
 
     return result

--- a/src/vips/voperation.lua
+++ b/src/vips/voperation.lua
@@ -73,7 +73,7 @@ end
 voperation.set = function(self, name, flags, match_image, value)
     local vob = self:vobject()
     local gtype_raw = vob:get_typeof(name)
-    local gtype = tonumber(gtype_raw)
+    local gtype = gvalue.comparable_type(gtype_raw)
 
     -- if the object wants an image and we have a constant, imageize it
     --

--- a/src/vips/voperation.lua
+++ b/src/vips/voperation.lua
@@ -72,17 +72,17 @@ end
 
 voperation.set = function(self, name, flags, match_image, value)
     local vob = self:vobject()
-    local gtype_raw = vob:get_typeof(name)
-    local gtype = gvalue.comparable_type(gtype_raw)
+    local gtype = vob:get_typeof(name)
+    local gtype_comp = gvalue.comparable_type(gtype)
 
     -- if the object wants an image and we have a constant, imageize it
     --
     -- if the object wants an image array, imageize any constants in the
     -- array
     if match_image then
-        if gtype == gvalue.image_type then
+        if gtype_comp == gvalue.image_type then
             value = match_image:imageize(value)
-        elseif gtype == gvalue.array_image_type then
+        elseif gtype_comp == gvalue.array_image_type then
             for i = 1, #value do
                 value[i] = match_image:imageize(value[i])
             end
@@ -96,7 +96,7 @@ voperation.set = function(self, name, flags, match_image, value)
         value = value:copy():copy_memory()
     end
 
-    return vob:set_type(name, value, gtype_raw)
+    return vob:set_type(name, value, gtype)
 end
 
 -- this is slow ... call as little as possible


### PR DESCRIPTION
Fixes:
- temporary files names on Windows (`/tmp` folder doesn't work)
- gtype for Lua5.1 on Windows (where both `gvalue.*_type` and `vips_lib` functions return cdata)

Lua 5.1 on Windows wasn't added to the CI testing, since two tests fail:
- `cache_spec` "can limit the number of operations to cache by open files" because `vips.get_max_mem()` returns cdata instead of number
- `meta_spec` "can remove metadata" because `im2:get_typeof("banana")` returns cdata instead of number