### PR TITLE
Fix crash with write_to_file/buffer with Lua 5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         if [[ ${{ matrix.os }} == macos* ]]; then
           brew install vips
         elif [[ ${{ matrix.os }} == ubuntu* ]]; then
+          sudo apt update
           sudo apt install --no-install-recommends libvips-dev
         fi
 

--- a/src/vips/Image_methods.lua
+++ b/src/vips/Image_methods.lua
@@ -370,20 +370,23 @@ end
 -- writers
 
 function Image_method:write_to_file(vips_filename, ...)
+    collectgarbage("stop")
     local filename = to_string_copy(vips_lib.vips_filename_get_filename(vips_filename))
     local options = to_string_copy(vips_lib.vips_filename_get_options(vips_filename))
     local name = vips_lib.vips_foreign_find_save(filename)
+    collectgarbage("restart")
     if name == ffi.NULL then
         error(verror.get())
     end
-
     return voperation.call(ffi.string(name), options,
             self, filename, unpack { ... })
 end
 
 function Image_method:write_to_buffer(format_string, ...)
+    collectgarbage("stop")
     local options = to_string_copy(vips_lib.vips_filename_get_options(format_string))
     local name = vips_lib.vips_foreign_find_save_buffer(format_string)
+    collectgarbage("restart")
     if name == ffi.NULL then
         error(verror.get())
     end


### PR DESCRIPTION
Not sure why, but garbage collection in `Image_method:write_to_file` makes `example/hello_world.lua` crash otherwise when run with Lua 5.4. This also happens with `Image_method:write_to_buffer`. 