### PR TITLE
Fix CI on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,17 @@ jobs:
 
     - uses: leafo/gh-actions-luarocks@v4
 
-    - name: Install libvips
+    - name: Install Ubuntu dependencies
+      if: runner.os == 'Linux'
       run: |
-        if [[ ${{ matrix.os }} == macos* ]]; then
-          brew install vips
-        elif [[ ${{ matrix.os }} == ubuntu* ]]; then
-          sudo apt update
-          sudo apt install --no-install-recommends libvips-dev
-        fi
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends libvips-dev
+
+    - name: Install macOS dependencies
+      if: runner.os == 'macOS'
+      run: |
+        brew install vips
+        echo "DYLD_LIBRARY_PATH=$(brew --prefix vips)/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Install lua-vips
       run: |


### PR DESCRIPTION
The `macos-latest` image now uses macOS 14 on an M1 runner.
https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

On M1 Macs, Homebrew installs into `/opt/homebrew` by default and no longer links into `/usr/local`. Therefore, we need to explicitly set `DYLD_LIBRARY_PATH` to `/opt/homebrew/lib` to ensure the dynamic linker can find libvips.