### PR TITLE
Modify image write to file test because of libvips 8.17 issue

### DIFF
--- a/spec/write_spec.lua
+++ b/spec/write_spec.lua
@@ -9,8 +9,7 @@ describe("test image write", function()
     end)
 
     describe("to file", function()
-        local array = { 1, 2, 3, 4 }
-        local im = vips.Image.new_from_array(array)
+        local im = vips.Image.black(100, 100)
         local tmp_png_filename = ffi.os == "Windows" and os.getenv("TMP") .. "\\x.png" or "/tmp/x.png"
         local tmp_jpg_filename = ffi.os == "Windows" and os.getenv("TMP") .. "\\x.jpg" or "/tmp/x.jpg"
 


### PR DESCRIPTION
Conversion from array to b-w colourspace is broken in libvips 8.17

Fixes #93 as suggested by @kleisauke 