### PR TITLE
Remove obsolete fix in test helper

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -4,26 +4,6 @@ require "vips"
 local assert = require "luassert.assert"
 local say = require "say"
 
--- TODO: Wait for https://github.com/Olivine-Labs/luassert/issues/148
--- Meanwhile, we're applying patch #150 here.
-
--- Pre-load the ffi module, such that it becomes part of the environment
--- and Busted will not try to GC and reload it. The ffi is not suited
--- for that and will occasionally segfault if done so.
-local ffi = require "ffi"
-
--- Patch ffi.cdef to only be called once with each definition, as it
--- will error on re-registering.
-local old_cdef = ffi.cdef
-local exists = {}
-ffi.cdef = function(def)
-    if exists[def] then
-        return
-    end
-    exists[def] = true
-    return old_cdef(def)
-end
-
 local function almost_equal(_, arguments)
     local threshold = arguments[3] or 0.001
 


### PR DESCRIPTION
The fix has become obsolete in 2018.